### PR TITLE
Add emojis to log output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ fn main() -> anyhow::Result<()> {
     init_logger(args.verbose);
 
     let cfg = config::load_yaml(&args.config)?;
-    log::debug!("Loaded config: {:#?}", cfg);
+    log::debug!("📋 Loaded config: {:#?}", cfg);
 
     let manager = WslManager::new();
 

--- a/src/wsl/manager.rs
+++ b/src/wsl/manager.rs
@@ -9,38 +9,38 @@ impl WslManager {
     }
 
     pub fn dry_run(&self, cfg: &AppConfig) -> anyhow::Result<()> {
-        info!("Dry run: WSL instance would be created");
+        info!("🧪 Dry run: WSL instance would be created");
         self.print_plan(cfg);
         Ok(())
     }
 
     pub fn create_instance(&self, cfg: &AppConfig) -> anyhow::Result<()> {
-        info!("Creating WSL instance");
+        info!("🚀 Creating WSL instance");
         self.print_plan(cfg);
-        info!("Instance creation not implemented yet (mock)");
+        info!("🧩 Instance creation not implemented yet (mock)");
         Ok(())
     }
 
     fn print_plan(&self, cfg: &AppConfig) {
-        debug!("Hostname: {}", cfg.hostname);
-        debug!("User: {}", cfg.username);
-        debug!("Install dir: {:?}", cfg.install_dir);
-        debug!("Cloud-init: {:?}", cfg.cloud_init);
+        debug!("🏷️  Hostname: {}", cfg.hostname);
+        debug!("👤 User: {}", cfg.username);
+        debug!("📦 Install dir: {:?}", cfg.install_dir);
+        debug!("☁️  Cloud-init: {:?}", cfg.cloud_init);
 
         match &cfg.image {
             ImageSource::Distro { name } => {
-                info!("Using WSL distro '{}'", name);
+                info!("🐧 Using WSL distro '{}'", name);
             }
             ImageSource::File { path } => {
-                info!("Using image file {:?}", path);
+                info!("🗂️  Using image file {:?}", path);
             }
         }
 
         if let Some(proxy) = &cfg.http_proxy {
-            debug!("HTTP proxy: {}", proxy);
+            debug!("🌐 HTTP proxy: {}", proxy);
         }
         if let Some(proxy) = &cfg.https_proxy {
-            debug!("HTTPS proxy: {}", proxy);
+            debug!("🔐 HTTPS proxy: {}", proxy);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make log output more expressive and easier to scan by adding emoji prefixes to key messages.

### Description
- Add emoji prefixes to debug/info logs in `src/wsl/manager.rs`, including `dry_run`, `create_instance`, `print_plan` fields, image source messages, and proxy logs, and add an emoji prefix to the config debug log in `src/main.rs`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f798a08f083228a752ec271014dd9)