### PR TITLE
ci(release): use RELEASE_TOKEN for checkout and semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -54,10 +56,14 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install semantic-release
         run: npm install -g semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @timada/semantic-release-cargo @semantic-release/git @semantic-release/github
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: semantic-release


### PR DESCRIPTION
### Motivation
- The release job could not push to protected `main` under repository rules, so semantic-release needs a PAT with push rights rather than the default runner token.

### Description
- Configure the release job `Checkout` step to use `token: ${{ secrets.RELEASE_TOKEN }}` so actions can push with the PAT.
- Set both `GITHUB_TOKEN` and `GH_TOKEN` to `{{ secrets.RELEASE_TOKEN }}` in the `Release` step so `semantic-release` publishes using the PAT.
- Ensure the workflow continues to set up Rust so cargo-dependent steps and `@timada/semantic-release-cargo` can run on the runner.

### Testing
- No automated tests were run because this change only modifies the CI workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878d29ec088322b69fa316397fe390)